### PR TITLE
Add "no duplicates" message to checkhealth output

### DIFF
--- a/lua/which-key/keys.lua
+++ b/lua/which-key/keys.lua
@@ -511,6 +511,10 @@ function M.check_health()
     vim.fn["health#report_info"](("old rhs: `%s`"):format(dup.other.rhs or ""))
     vim.fn["health#report_info"](("new rhs: `%s`"):format(dup.cmd or ""))
   end
+  if next(M.duplicates) == nil then
+    vim.fn["health#report_info"]("No duplicate keymaps found")
+  end
+
 end
 
 ---@param mode string


### PR DESCRIPTION
This adds a simple INFO message to the checkhealth output when no duplicates are found.

```which_key: health#which_key#check
========================================================================
## WhichKey: checking conflicting keymaps
  - INFO: No duplicate keymaps found

```